### PR TITLE
Update FastBitmap.csproj

### DIFF
--- a/FastBitmap/FastBitmap.csproj
+++ b/FastBitmap/FastBitmap.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>Hazdryx.FastBitmap</PackageId>
     <Authors>Christopher Bishop</Authors>


### PR DESCRIPTION
Change `net5.0` to `netstandard2.0`. I had to use this library in mono and cannot. Update in to netstandard2.0 pls. (it compiles and works just fine in netstandard2.0)